### PR TITLE
Change ActiveMQ to the Apache pre-build image

### DIFF
--- a/mq/activemq/Dockerfile
+++ b/mq/activemq/Dockerfile
@@ -1,3 +1,1 @@
-FROM rmohr/activemq:5.15.9-alpine
-
-CMD /bin/sh -c /opt/activemq/bin/activemq console
+FROM apache/activemq-classic:5.18.3

--- a/mq/activemq/docker-compose.yml
+++ b/mq/activemq/docker-compose.yml
@@ -4,9 +4,5 @@ services:
   activemq:
     image: private.docker.nexus.frankframework.org/ff-test/mq/activemq
     build: .
-    entrypoint:
-      - "/bin/sh"
-      - "-c"
-      - "/opt/activemq/bin/activemq console"
     ports:
       - "61616:61616"


### PR DESCRIPTION
This version works with the current CI/CD.

6.0.1 won't work, jet. 